### PR TITLE
(maint) Upgrade compojure to 1.3.3 for Clojure 1.7.0 compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [org.clojure/tools.reader "0.8.9"]
                  [ring/ring-core "1.3.2"]
                  [bidi "1.18.9"]
-                 [compojure "1.3.2"]
+                 [compojure "1.3.3"]
                  [prismatic/schema "0.4.0"]
                  [puppetlabs/kitchensink "1.1.0"]]
 


### PR DESCRIPTION
This commit updates compojure to 1.3.3 so that projects like PuppetDB
using Clojure 1.7.0 can use comidi with StringReader errors cause by
compojure < 1.3.3 with Clojure 1.7.0.