### PR TITLE
(maint) Make use of Bidi schema introduced in 1.20.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,9 @@
                  [org.clojure/tools.reader "0.8.9"]
                  [ring/ring-core "1.3.2"]
                  [commons-io "2.4"]
-                 [bidi "1.18.9" :exclusions [org.clojure/clojurescript]]
+                 [bidi "1.21.0" :exclusions [org.clojure/clojurescript]]
                  [compojure "1.3.3"]
-                 [prismatic/schema "0.4.0"]
+                 [prismatic/schema "0.4.3"]
                  [puppetlabs/kitchensink "1.1.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"

--- a/test/puppetlabs/comidi_test.clj
+++ b/test/puppetlabs/comidi_test.clj
@@ -25,36 +25,6 @@
     (is (nil? (schema/check Handler {:get (fn [] :foo)})))
     (is (nil? (schema/check Handler {:post :foo})))))
 
-(deftest pattern-schema-test
-  (testing "pattern schema"
-    (is (nil? (schema/check BidiPattern "/foo")))
-    (is (nil? (schema/check BidiPattern :foo)))
-    (is (nil? (schema/check BidiPattern ["/foo/" :foo "/foo"])))
-    (is (nil? (schema/check BidiPattern ["/foo/" [#".*" :rest]])))))
-
-(deftest destination-schema-test
-  (testing "route destination schema"
-    (is (nil? (schema/check BidiRouteDestination :foo)))
-    (is (nil? (schema/check BidiRouteDestination (fn [] nil))))
-    (is (nil? (schema/check BidiRouteDestination {:get (fn [] nil)})))
-    (is (nil? (schema/check BidiRouteDestination {:get :my-handler})))
-    (is (nil? (schema/check BidiRouteDestination [[["/foo/" :foo "/foo"] :foo]])))
-    (is (not (nil? (schema/check BidiRouteDestination [["/foo/" :foo "/foo"] :foo]))))
-    (is (nil? (schema/check BidiRouteDestination [[["/foo/" :foo]
-                                                   :foo-handler]
-                                                  [["/bar/" :bar]
-                                                   {:get :bar-handler}]])))))
-
-(deftest route-schema-test
-  (testing "route schema"
-    (is (nil? (schema/check BidiRoute [:foo :foo])))
-    (is (nil? (schema/check BidiRoute ["/foo" [[:foo :foo]]])))
-    (is (not (nil? (schema/check BidiRoute ["/foo" [:foo :foo]]))))
-    (is (nil? (schema/check BidiRoute ["" [[["/foo/" :foo]
-                                            :foo-handler]
-                                           [["/bar/" :bar]
-                                            {:get :bar-handler}]]])))))
-
 (deftest update-route-info-test
   (let [orig-route-info {:path           []
                          :request-method :any}]
@@ -70,7 +40,7 @@
     (testing "keyword path elements get added to the path"
       (is (= {:path           [:foo]
               :request-method :any}
-             (update-route-info* orig-route-info :foo))))
+             (update-route-info* orig-route-info [:foo]))))
     (testing "vector path elements get flattened and added to the path"
       (is (= {:path           ["/foo/" :foo]
               :request-method :any}
@@ -88,7 +58,7 @@
                       [["/bar/" :bar]
                        [["/baz" {:get :baz-handler}]
                         ["/bam" {:put :bam-handler}]
-                        ["/bap" {:any :bap-handler}]]]
+                        ["/bap" {:options :bap-handler}]]]
                       ["/buzz" {:post :buzz-handler}]]]
           expected-foo-meta {:path           ["" "/foo/" :foo]
                              :route-id           "foo-:foo"
@@ -101,7 +71,7 @@
                              :request-method :put}
           expected-bap-meta {:path           ["" "/bar/" :bar "/bap"]
                              :route-id           "bar-:bar-bap"
-                             :request-method :any}
+                             :request-method :options}
           expected-buzz-meta {:path           ["" "/buzz"]
                               :route-id           "buzz"
                               :request-method :post}]


### PR DESCRIPTION
Bidi introduced schema in 1.20.0 and there are some deviations between ours and theirs. This commit modifies Comidi to use the Bidi schema where possible and makes some small updates to the remainder to align a bit better.