### PR TITLE
(maint) comidi routes can only map to Ring handlers

### DIFF
--- a/src/puppetlabs/comidi.clj
+++ b/src/puppetlabs/comidi.clj
@@ -231,21 +231,19 @@
   it with the request as a parameter. (This code is largely copied from the
   bidi upstream, but we add support for inserting the match-context via
   middleware.)"
-  ([route handler-fn]
-   (fn [{:keys [uri path-info] :as req}]
-     (let [path (or path-info uri)
-           {:keys [handler route-params] :as match-context}
-           (or (:match-context req)
-               (apply bidi/match-route route path (apply concat (seq req))))]
-       (when handler
-         (bidi-ring/request
-           (handler-fn handler)
-           (-> req
-               (update-in [:params] merge route-params)
-               (update-in [:route-params] merge route-params))
-           (apply dissoc match-context :handler (keys req))
-           )))))
-  ([route] (make-handler route identity)))
+  [route]
+  (fn [{:keys [uri path-info] :as req}]
+    (let [path (or path-info uri)
+          {:keys [handler route-params] :as match-context}
+          (or (:match-context req)
+              (apply bidi/match-route route path (apply concat (seq req))))]
+      (when handler
+        (bidi-ring/request
+         handler
+         (-> req
+             (update-in [:params] merge route-params)
+             (update-in [:route-params] merge route-params))
+         (apply dissoc match-context :handler (keys req)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private - helpers for compojure-like syntax
@@ -316,15 +314,10 @@ context :- bidi-schema/RoutePair
 
 (schema/defn ^:always-validate
   routes->handler :- (schema/pred fn?)
-  "Given a bidi route tree, converts into a ring request handler function.  You
-  may pass an optional handler function which will be wrapped around the
-  bidi leaf."
-  ([routes :- bidi-schema/RoutePair
-    handler-fn :- (schema/maybe (schema/pred fn?))]
-    (let [compiled-routes (bidi/compile-route routes)]
-      (make-handler compiled-routes handler-fn)))
-  ([routes]
-   (routes->handler routes identity)))
+  "Given a bidi route tree, converts into a ring request handler function"
+  [routes :- bidi-schema/RoutePair]
+   (let [compiled-routes (bidi/compile-route routes)]
+     (make-handler compiled-routes)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public - compojure-like convenience macros

--- a/test/puppetlabs/comidi_test.clj
+++ b/test/puppetlabs/comidi_test.clj
@@ -134,19 +134,6 @@
               :bar "there"}
              (handler {:uri "/foo/hi/bar/there"}))))))
 
-(deftest routes->handler-fn-test
-  (let [handler (routes->handler
-                  (context ["/foo/" :foo]
-                           [["/bar/" :bar]
-                            (fn [req] (:route-params req))])
-                  (fn [f]
-                    (fn [req]
-                      {:result (into {} (map (fn [[k v]] [k (str "wrapped " v)])
-                                             (f req)))})))]
-    (is (= {:result {:foo "wrapped hi"
-                     :bar "wrapped there"}}
-           (handler {:uri "/foo/hi/bar/there"})))))
-
 (deftest compojure-macros-test
   (let [routes (context ["/foo/" :foo]
                         (ANY ["/any/" :any] [foo any]


### PR DESCRIPTION
Bidi allows routes to map to any value, not just Ring handlers. Comidi expects the value to be a Ring handler (and only ever provides one itself) but exposes a couple of overloaded functions that allow a user to in principle provide something different. This commit removes that ability.
