### PR TITLE
(MAINT) added 'resources' route utility fn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,8 @@
 
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.reader "0.8.9"]
+                 [clj-time "0.7.0"]
+
                  [ring/ring-core "1.3.2"]
                  [commons-io "2.4"]
                  [bidi "1.21.0" :exclusions [org.clojure/clojurescript]]


### PR DESCRIPTION
This commit adds a `resources` utility function, borrowed
from the compojure version, to facilitate serving up
files from the jar resources of a project.