### PR TITLE
(TK-464) Update to bidi 2.1.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,12 +6,12 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.4.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.6.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
 
-                 [bidi "2.0.12"]
+                 [bidi "2.1.3"]
                  [compojure]
                  [prismatic/schema]
                  [puppetlabs/kitchensink]]

--- a/src/puppetlabs/comidi.clj
+++ b/src/puppetlabs/comidi.clj
@@ -167,11 +167,7 @@
     (update-in route-info [:path] conj "!")
 
     (sequential? pattern)
-    (if-let [next (first pattern)]
-      (update-route-info*
-        (update-in route-info [:path] conj next)
-        (rest pattern))
-      route-info)
+    (update-in route-info [:path] into pattern)
 
     :else
     (update-in route-info [:path] conj pattern)))


### PR DESCRIPTION
This commit updates bidi to 2.1.3. Due to a schema change in bidi that
no longer allows empty lists, this commit also updates the recursion in
`update-route-info` to no longer recurse when the processing the last
element in the list.