### PR TITLE
Fix test failure with Clojure 1.9+

### DIFF
--- a/test/puppetlabs/comidi_test.clj
+++ b/test/puppetlabs/comidi_test.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.comidi-test
-  (require [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
            [puppetlabs.comidi :as comidi :refer :all]
            [schema.test :as schema-test]
            [schema.core :as schema]

--- a/test/puppetlabs/comidi_test.clj
+++ b/test/puppetlabs/comidi_test.clj
@@ -1,10 +1,10 @@
 (ns puppetlabs.comidi-test
   (:require [clojure.test :refer :all]
-           [puppetlabs.comidi :as comidi :refer :all]
-           [schema.test :as schema-test]
-           [schema.core :as schema]
-           [clojure.zip :as zip]
-           [bidi.bidi :as bidi]))
+            [puppetlabs.comidi :as comidi :refer :all]
+            [schema.test :as schema-test]
+            [schema.core :as schema]
+            [clojure.zip :as zip]
+            [bidi.bidi :as bidi]))
 
 (use-fixtures :once schema-test/validate-schemas)
 


### PR DESCRIPTION
Quoting the Clojure documentation:

    Use :require in the ns macro in preference to calling this directly.

As kindly pointed out by Alex Miller (@puredanger), the “require” syntax
happened to work accidentally in Clojure 1.8, but that's now rejected by
Clojure 1.9+ with:

    Call to clojure.core/ns did not conform to spec: […] Extra input

Debian bug report: https://bugs.debian.org/889125

Notes:

- This patch was successfully tested on Debian unstable with Clojure 1.9.0.

- I'm not sure how to reference the github issue in the commit message as other fixes seemed to reference some other bug tracker (TK-* namespace)? Anyway: this would fix #36.