### PR TITLE
(maint) update clj-parent 4.9.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.8.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.9.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
Update the dependencies via clj-parent to avoid scanners reporting vulnerable dependencies.